### PR TITLE
API server route for processing clicks

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": "^2.1.1",
-    "@planship/react": "0.1.2",
+    "@planship/react": "^0.1.3",
     "next": "14.0.3",
     "react": "^18",
     "react-dom": "^18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^2.1.1
     version: 2.1.1(react@18.2.0)
   '@planship/react':
-    specifier: 0.1.2
-    version: 0.1.2
+    specifier: ^0.1.3
+    version: 0.1.3
   next:
     specifier: 14.0.3
     version: 14.0.3(react-dom@18.2.0)(react@18.2.0)
@@ -316,8 +316,8 @@ packages:
     dev: true
     optional: true
 
-  /@planship/fetch@0.1.0:
-    resolution: {integrity: sha512-CQrobBs/oL1wgSwnBNm4x4fRiDsDcSeRWS2NJ7uG6QGuuMN+WAqN9vuvtLgMKLTepjS2qfbbIDQlLtzveiXujA==}
+  /@planship/fetch@0.1.1:
+    resolution: {integrity: sha512-QNbFAx6pTKckx61cUtM68+eU+z6m4TkLBYjhbnFl3kdO7x+amAapIddcgO4rQ3lkWQ9b36n58ASRoP2cHiat4A==}
     dependencies:
       '@planship/models': 0.1.0
     dev: false
@@ -326,10 +326,10 @@ packages:
     resolution: {integrity: sha512-/8Tlu3SmUemVNAeNJlUsf7vUwKRNxzCytDW61NEC9HWcYqonqF7WfVVuOvc/SC7/ovmf6alVxhZhJTcIqFVKWQ==}
     dev: false
 
-  /@planship/react@0.1.2:
-    resolution: {integrity: sha512-j1Mnco5Ounv+JZnaKCyJt2sjreZ/00sKAueXOZPxM0Hxw+IsabzuxoAhxBVEWms+tFfQ8yI5iSdq2HsSCdmufw==}
+  /@planship/react@0.1.3:
+    resolution: {integrity: sha512-YFi3EJTfHl9dZdzdM3hKFPD6sbtRJ2eSRniuxICJAJevu+qXnIH60t2tggdn/dGhZU4fttt7+iUIhdSuOJmK9A==}
     dependencies:
-      '@planship/fetch': 0.1.0
+      '@planship/fetch': 0.1.1
     dev: false
 
   /@rushstack/eslint-patch@1.6.1:

--- a/src/app/api/click/route.ts
+++ b/src/app/api/click/route.ts
@@ -1,0 +1,14 @@
+import { Planship, TokenResponse } from '@planship/fetch'
+import { getPlanshipOnServer } from '@/lib/planship'
+
+// Server API route that records and reports a button click
+export async function POST(request: Request) {
+  const body = await request.json()
+  console.log('Button click received!')
+  console.dir(body)
+
+  const planship: Planship = getPlanshipOnServer()
+  planship.reportUsage(body.customerId, 'button-click', body.count)
+
+  return new Response()
+}

--- a/src/app/components/ProjectButton.tsx
+++ b/src/app/components/ProjectButton.tsx
@@ -1,12 +1,21 @@
 import { useState } from 'react'
 import { usePlanshipCustomer } from '@planship/react'
+import { useCurrentUser } from './CurrentUserProvider'
 
-function RenderProjectButton(projectType: string) {
-  const { planshipCustomerApiClient, entitlements } = usePlanshipCustomer()
+function RenderProjectButton(projectType: string, projectName: string) {
+  const { entitlements, setEntitlements } = usePlanshipCustomer()
+  const currentUser = useCurrentUser()
   let [batchClicks, setBatchClicks] = useState(() => 5)
 
   const generateClicks = (count: number) => {
-    planshipCustomerApiClient?.reportUsage('button-click', count)
+    fetch('/api/click', {
+      method: 'post',
+      body: JSON.stringify({
+        customerId: currentUser.email,
+        count,
+        projectName
+      })
+    })
   }
 
   const renderNoMoreClicks = (canGenerateButtonClick: boolean) => {
@@ -67,5 +76,5 @@ function RenderProjectButton(projectType: string) {
 }
 
 export default function ProjectButton({ project, className }: { project: Object; className: string }) {
-  return <div className={className}>{RenderProjectButton(project.type)}</div>
+  return <div className={className}>{RenderProjectButton(project.type, project.name)}</div>
 }

--- a/src/app/lib/planship.ts
+++ b/src/app/lib/planship.ts
@@ -1,14 +1,25 @@
 import { Planship } from '@planship/fetch'
 
+// Wrap nextjs fetch so there is no caching
+function planshipFetch(url, options) {
+  return fetch(url, {
+    ...options,
+    cache: 'no-store'
+  })
+}
+
+const planshipClient: Planship = new Planship(
+  'clicker-demo',
+  process.env.PLANSHIP_API_SERVER_URL || 'https://api.planship.io',
+  process.env.PLANSHIP_API_CLIENT_ID || '',
+  process.env.PLANSHIP_API_CLIENT_SECRET || '',
+  planshipFetch
+)
+
 export async function getAccessToken() {
   return await fetch('/api/planshipToken').then((response) => response.text())
 }
 
 export function getPlanshipOnServer() {
-  return new Planship(
-    'clicker-demo',
-    process.env.PLANSHIP_API_SERVER_URL || 'https://api.planship.io',
-    process.env.PLANSHIP_API_CLIENT_ID || '',
-    process.env.PLANSHIP_API_CLIENT_SECRET || ''
-  )
+  return planshipClient
 }


### PR DESCRIPTION
This PR, when merged, will move reporting `button-click` usage to Planship to the server side via the `/api/click` NextJS API server route. This mirrors a similar change in the Nuxt3 example app: https://github.com/planship/planship-nuxt-example/pull/5