### PR TITLE
Move to the latest @planship/react (token reuse fix)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,4 +3,4 @@ PLANSHIP_API_CLIENT_SECRET=<Planship API client Secret>
 
 PLANSHIP_API_SERVER_URL=<Planship API endpoint URL accessible from the application server, default: https://api.planship.io>
 NEXT_PUBLIC_PLANSHIP_API_CLIENT_URL=<Planship API endpoint URL accessible from the client (browser), default: https://api.planship.io>
-NEXT_PUBLIC_WEBSOCKET_URL=<Planship API websocket endpoint accessible from the client (browser), default: wss://api.planship.io>
+NEXT_PUBLIC_PLANSHIP_WEBSOCKET_URL=<Planship API websocket endpoint accessible from the client (browser), default: wss://api.planship.io>

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@headlessui/react": "^1.7.18",
     "@heroicons/react": "^2.1.1",
-    "@planship/react": "0.2.0",
+    "@planship/react": "^0.2.1",
     "next": "14.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^2.1.1
     version: 2.1.1(react@18.2.0)
   '@planship/react':
-    specifier: 0.2.0
-    version: 0.2.0
+    specifier: ^0.2.1
+    version: 0.2.1
   next:
     specifier: 14.0.3
     version: 14.0.3(react-dom@18.2.0)(react@18.2.0)
@@ -317,8 +317,8 @@ packages:
     dev: true
     optional: true
 
-  /@planship/fetch@0.2.1:
-    resolution: {integrity: sha512-/KdPVqXXAGHbgVRsX6tLsjhS8fZYI+simvJeGwxltOMg7Eeud2mUDG75g0BkOf2iQLeOUlYV9GJJYUIElXYN+Q==}
+  /@planship/fetch@0.2.2:
+    resolution: {integrity: sha512-5QoTCBoqOsOjJjiYhNC39HX7vbiYgnF08YQocT2wlrZO0s9CVIwZwS6CsOQDzqvFIlyk2m/9WFKmmA2TQaW8jQ==}
     dependencies:
       '@planship/models': 0.2.1
     dev: false
@@ -327,10 +327,10 @@ packages:
     resolution: {integrity: sha512-Tw2wMFp4+IZZmnubngMEV6RXXCUx/rX/FDLPImR5QKh0qVuRomAh21n22X9FIl2Qi8GcHiLIQ4geNlxuP7AQzw==}
     dev: false
 
-  /@planship/react@0.2.0:
-    resolution: {integrity: sha512-u5cJPt3nxglqJE8Igr4wxlMvMpRk3kiFCmOb3g3M/T6Nyc9M0vXOdu5ceIPycOU/Koty/5BZGSwRA6z7DVW0pQ==}
+  /@planship/react@0.2.1:
+    resolution: {integrity: sha512-DtAhiuWWnAMZ+/koF/nh2kJz+A659skR1eKJlnfQ4iq9PYHSpB97kXcBg5gImvvTNH4iF3nSrbajsWusmO5fmw==}
     dependencies:
-      '@planship/fetch': 0.2.1
+      '@planship/fetch': 0.2.2
     dev: false
 
   /@rushstack/eslint-patch@1.7.2:

--- a/src/app/components/PlanshipProvider.tsx
+++ b/src/app/components/PlanshipProvider.tsx
@@ -18,10 +18,10 @@ export default function PlanshipProvider({
   const PlanshipCustomerProvider = withPlanshipCustomerProvider(
     {
       baseUrl: process.env.NEXT_PUBLIC_PLANSHIP_API_CLIENT_URL,
-      websocketUrl: process.env.NEXT_PUBLIC_WEBSOCKET_URL,
+      webSocketUrl: process.env.NEXT_PUBLIC_PLANSHIP_WEBSOCKET_URL,
       slug: 'clicker-demo',
       customerId: currentUser.email,
-      getAccessToken: getAccessToken
+      getAccessToken
     },
     initialEntitlements,
     initialSubscrptions

--- a/src/app/lib/planship.ts
+++ b/src/app/lib/planship.ts
@@ -15,6 +15,7 @@ const planshipClient: Planship = new Planship(
     clientSecret: process.env.PLANSHIP_API_CLIENT_SECRET
   },
   {
+    baseUrl: process.env.PLANSHIP_API_SERVER_URL,
     extras: {
       fetchApi: planshipFetch
     }


### PR DESCRIPTION
This PR, when merged, will update @planship/react dependency version to 0.2.1.