### PR TITLE
Update @planship/react version to 0.2.3

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,2 @@
 PLANSHIP_API_CLIENT_ID=<Planship API client ID>
 PLANSHIP_API_CLIENT_SECRET=<Planship API client Secret>
-
-PLANSHIP_API_SERVER_URL=<Planship API endpoint URL accessible from the application server, default: https://api.planship.io>
-NEXT_PUBLIC_PLANSHIP_API_CLIENT_URL=<Planship API endpoint URL accessible from the client (browser), default: https://api.planship.io>
-NEXT_PUBLIC_PLANSHIP_WEBSOCKET_URL=<Planship API websocket endpoint accessible from the client (browser), default: wss://api.planship.io>

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@headlessui/react": "^1.7.18",
     "@heroicons/react": "^2.1.1",
-    "@planship/react": "^0.2.1",
+    "@planship/react": "0.2.3-alpha",
     "next": "14.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@headlessui/react": "^1.7.18",
     "@heroicons/react": "^2.1.1",
-    "@planship/react": "0.2.3-alpha",
+    "@planship/react": "0.2.3",
     "next": "14.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^2.1.1
     version: 2.1.1(react@18.2.0)
   '@planship/react':
-    specifier: ^0.2.1
-    version: 0.2.1
+    specifier: 0.2.3-alpha
+    version: 0.2.3-alpha
   next:
     specifier: 14.0.3
     version: 14.0.3(react-dom@18.2.0)(react@18.2.0)
@@ -317,20 +317,20 @@ packages:
     dev: true
     optional: true
 
-  /@planship/fetch@0.2.2:
-    resolution: {integrity: sha512-5QoTCBoqOsOjJjiYhNC39HX7vbiYgnF08YQocT2wlrZO0s9CVIwZwS6CsOQDzqvFIlyk2m/9WFKmmA2TQaW8jQ==}
+  /@planship/fetch@0.2.3:
+    resolution: {integrity: sha512-2uiC5fMJ26VdJrbybeCLYYLjVVkDtEO/jouLGlFxmH/XQ3rlijy3YaGAK6pESX1NAf0boZsClxSRJZ0nLJe7ow==}
     dependencies:
-      '@planship/models': 0.2.1
+      '@planship/models': 0.2.2
     dev: false
 
-  /@planship/models@0.2.1:
-    resolution: {integrity: sha512-Tw2wMFp4+IZZmnubngMEV6RXXCUx/rX/FDLPImR5QKh0qVuRomAh21n22X9FIl2Qi8GcHiLIQ4geNlxuP7AQzw==}
+  /@planship/models@0.2.2:
+    resolution: {integrity: sha512-hYnp0WXUsgbOE/IRlN9Jxjyp47+a425lOjtwO3DYGysk+jHTcnY9GgRsevnctXjE5kOvXJKXHnkvlJfFZbLH3w==}
     dev: false
 
-  /@planship/react@0.2.1:
-    resolution: {integrity: sha512-DtAhiuWWnAMZ+/koF/nh2kJz+A659skR1eKJlnfQ4iq9PYHSpB97kXcBg5gImvvTNH4iF3nSrbajsWusmO5fmw==}
+  /@planship/react@0.2.3-alpha:
+    resolution: {integrity: sha512-YBvy/xt3tJOhpHuvY+55zWsnO4oEwDUvLOmd2yRWCqbgdvNMu69cbiaT4cXhQis/3evJtQwzjFU4EVs4mtbXgA==}
     dependencies:
-      '@planship/fetch': 0.2.2
+      '@planship/fetch': 0.2.3
     dev: false
 
   /@rushstack/eslint-patch@1.7.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^2.1.1
     version: 2.1.1(react@18.2.0)
   '@planship/react':
-    specifier: 0.2.3-alpha
-    version: 0.2.3-alpha
+    specifier: 0.2.3
+    version: 0.2.3
   next:
     specifier: 14.0.3
     version: 14.0.3(react-dom@18.2.0)(react@18.2.0)
@@ -327,8 +327,8 @@ packages:
     resolution: {integrity: sha512-hYnp0WXUsgbOE/IRlN9Jxjyp47+a425lOjtwO3DYGysk+jHTcnY9GgRsevnctXjE5kOvXJKXHnkvlJfFZbLH3w==}
     dev: false
 
-  /@planship/react@0.2.3-alpha:
-    resolution: {integrity: sha512-YBvy/xt3tJOhpHuvY+55zWsnO4oEwDUvLOmd2yRWCqbgdvNMu69cbiaT4cXhQis/3evJtQwzjFU4EVs4mtbXgA==}
+  /@planship/react@0.2.3:
+    resolution: {integrity: sha512-KPccMhjqsvjv1n1Q7RBPdM7nTS3wc5SEkpsR5XXDjXue9EsHHypkXYdBDuwnZhvpWUYHWbwcT0SoZqlkczWDEg==}
     dependencies:
       '@planship/fetch': 0.2.3
     dev: false

--- a/src/app/components/PlanshipProvider.tsx
+++ b/src/app/components/PlanshipProvider.tsx
@@ -17,8 +17,6 @@ export default function PlanshipProvider({
   const currentUser = useCurrentUser()
   const PlanshipCustomerProvider = withPlanshipCustomerProvider(
     {
-      baseUrl: process.env.NEXT_PUBLIC_PLANSHIP_API_CLIENT_URL,
-      webSocketUrl: process.env.NEXT_PUBLIC_PLANSHIP_WEBSOCKET_URL,
       slug: 'clicker-demo',
       customerId: currentUser.email,
       getAccessToken

--- a/src/app/lib/planship.ts
+++ b/src/app/lib/planship.ts
@@ -15,7 +15,6 @@ const planshipClient: Planship = new Planship(
     clientSecret: process.env.PLANSHIP_API_CLIENT_SECRET
   },
   {
-    baseUrl: process.env.PLANSHIP_API_SERVER_URL,
     extras: {
       fetchApi: planshipFetch
     }


### PR DESCRIPTION
This PR, when approved, will add the following changes:
 - Update `@planship/fetch` version to 0.2.3 (latest version rebuilt for the current production version of the Planship API)
 - Remove Planship API endpoint URL configuration via env variables