### PR TITLE
Create a default Planship customer and initial subscription

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,14 @@
 {
-  "extends": ["next/core-web-vitals", "prettier"]
+  "extends": [
+    "next/core-web-vitals",
+    "prettier",
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "rules": {
+    "@typescript-eslint/consistent-type-imports": "error"
+  },
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "root": true
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "@types/node": "^20.11.19",
     "@types/react": "^18.2.56",
     "@types/react-dom": "^18.2.19",
+    "@typescript-eslint/eslint-plugin": "^7.8.0",
+    "@typescript-eslint/parser": "^7.8.0",
     "autoprefixer": "^10.4.17",
     "eslint": "^8.56.0",
     "eslint-config-next": "14.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,12 @@ devDependencies:
   '@types/react-dom':
     specifier: ^18.2.19
     version: 18.2.19
+  '@typescript-eslint/eslint-plugin':
+    specifier: ^7.8.0
+    version: 7.8.0(@typescript-eslint/parser@7.8.0)(eslint@8.56.0)(typescript@5.3.3)
+  '@typescript-eslint/parser':
+    specifier: ^7.8.0
+    version: 7.8.0(eslint@8.56.0)(typescript@5.3.3)
   autoprefixer:
     specifier: ^10.4.17
     version: 10.4.17(postcss@8.4.35)
@@ -358,6 +364,10 @@ packages:
     resolution: {integrity: sha512-I5lerX+RWxLM+zw35gwwQIoLvtkOm0ecuQUlEjNey+Ga6TnR66WKLBnSHre59onugxhpDLT2nofRYzxf+izDFQ==}
     dev: false
 
+  /@types/json-schema@7.0.15:
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+    dev: true
+
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
     dev: true
@@ -390,6 +400,39 @@ packages:
     resolution: {integrity: sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==}
     dev: true
 
+  /@types/semver@7.5.8:
+    resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
+    dev: true
+
+  /@typescript-eslint/eslint-plugin@7.8.0(@typescript-eslint/parser@7.8.0)(eslint@8.56.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-gFTT+ezJmkwutUPmB0skOj3GZJtlEGnlssems4AjkVweUPGj7jRwwqg0Hhg7++kPGJqKtTYx+R05Ftww372aIg==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^7.0.0
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@eslint-community/regexpp': 4.10.0
+      '@typescript-eslint/parser': 7.8.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/scope-manager': 7.8.0
+      '@typescript-eslint/type-utils': 7.8.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 7.8.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/visitor-keys': 7.8.0
+      debug: 4.3.4
+      eslint: 8.56.0
+      graphemer: 1.4.0
+      ignore: 5.3.1
+      natural-compare: 1.4.0
+      semver: 7.6.0
+      ts-api-utils: 1.3.0(typescript@5.3.3)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -411,6 +454,27 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/parser@7.8.0(eslint@8.56.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-KgKQly1pv0l4ltcftP59uQZCi4HUYswCLbTqVZEJu7uLX8CTLyswqMLqLN+2QFz4jCptqWVV4SB7vdxcH2+0kQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 7.8.0
+      '@typescript-eslint/types': 7.8.0
+      '@typescript-eslint/typescript-estree': 7.8.0(typescript@5.3.3)
+      '@typescript-eslint/visitor-keys': 7.8.0
+      debug: 4.3.4
+      eslint: 8.56.0
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/scope-manager@6.21.0:
     resolution: {integrity: sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -419,9 +483,42 @@ packages:
       '@typescript-eslint/visitor-keys': 6.21.0
     dev: true
 
+  /@typescript-eslint/scope-manager@7.8.0:
+    resolution: {integrity: sha512-viEmZ1LmwsGcnr85gIq+FCYI7nO90DVbE37/ll51hjv9aG+YZMb4WDE2fyWpUR4O/UrhGRpYXK/XajcGTk2B8g==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    dependencies:
+      '@typescript-eslint/types': 7.8.0
+      '@typescript-eslint/visitor-keys': 7.8.0
+    dev: true
+
+  /@typescript-eslint/type-utils@7.8.0(eslint@8.56.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-H70R3AefQDQpz9mGv13Uhi121FNMh+WEaRqcXTX09YEDky21km4dV1ZXJIp8QjXc4ZaVkXVdohvWDzbnbHDS+A==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 7.8.0(typescript@5.3.3)
+      '@typescript-eslint/utils': 7.8.0(eslint@8.56.0)(typescript@5.3.3)
+      debug: 4.3.4
+      eslint: 8.56.0
+      ts-api-utils: 1.3.0(typescript@5.3.3)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/types@6.21.0:
     resolution: {integrity: sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==}
     engines: {node: ^16.0.0 || >=18.0.0}
+    dev: true
+
+  /@typescript-eslint/types@7.8.0:
+    resolution: {integrity: sha512-wf0peJ+ZGlcH+2ZS23aJbOv+ztjeeP8uQ9GgwMJGVLx/Nj9CJt17GWgWWoSmoRVKAX2X+7fzEnAjxdvK2gqCLw==}
+    engines: {node: ^18.18.0 || >=20.0.0}
     dev: true
 
   /@typescript-eslint/typescript-estree@6.21.0(typescript@5.3.3):
@@ -446,11 +543,60 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/typescript-estree@7.8.0(typescript@5.3.3):
+    resolution: {integrity: sha512-5pfUCOwK5yjPaJQNy44prjCwtr981dO8Qo9J9PwYXZ0MosgAbfEMB008dJ5sNo3+/BN6ytBPuSvXUg9SAqB0dg==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 7.8.0
+      '@typescript-eslint/visitor-keys': 7.8.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.4
+      semver: 7.6.0
+      ts-api-utils: 1.3.0(typescript@5.3.3)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/utils@7.8.0(eslint@8.56.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-L0yFqOCflVqXxiZyXrDr80lnahQfSOfc9ELAAZ75sqicqp2i36kEZZGuUymHNFoYOqxRT05up760b4iGsl02nQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.5.8
+      '@typescript-eslint/scope-manager': 7.8.0
+      '@typescript-eslint/types': 7.8.0
+      '@typescript-eslint/typescript-estree': 7.8.0(typescript@5.3.3)
+      eslint: 8.56.0
+      semver: 7.6.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/visitor-keys@6.21.0:
     resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
       '@typescript-eslint/types': 6.21.0
+      eslint-visitor-keys: 3.4.3
+    dev: true
+
+  /@typescript-eslint/visitor-keys@7.8.0:
+    resolution: {integrity: sha512-q4/gibTNBQNA0lGyYQCmWRS5D15n8rXh4QjK3KV+MBPlTYHpfBUT3D3PaPR/HeNiI9W6R7FvlkcGhNyAoP+caA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    dependencies:
+      '@typescript-eslint/types': 7.8.0
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -1038,7 +1184,7 @@ packages:
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.8.0)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
@@ -1078,7 +1224,7 @@ packages:
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.8.0)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -1120,7 +1266,36 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@7.8.0)(eslint-import-resolver-node@0.3.9)(eslint@8.56.0):
+    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 7.8.0(eslint@8.56.0)(typescript@5.3.3)
+      debug: 3.2.7
+      eslint: 8.56.0
+      eslint-import-resolver-node: 0.3.9
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.8.0)(eslint@8.56.0):
     resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -1130,7 +1305,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 7.8.0(eslint@8.56.0)(typescript@5.3.3)
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.4
       array.prototype.flat: 1.3.2
@@ -1139,7 +1314,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.8.0)(eslint-import-resolver-node@0.3.9)(eslint@8.56.0)
       hasown: 2.0.1
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -1944,6 +2119,13 @@ packages:
       brace-expansion: 2.0.1
     dev: true
 
+  /minimatch@9.0.4:
+    resolution: {integrity: sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: true
+
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
     dev: true
@@ -2692,6 +2874,15 @@ packages:
 
   /ts-api-utils@1.2.1(typescript@5.3.3):
     resolution: {integrity: sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+    dependencies:
+      typescript: 5.3.3
+    dev: true
+
+  /ts-api-utils@1.3.0(typescript@5.3.3):
+    resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'

--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -1,6 +1,6 @@
 import { getCurrentUser } from '@/lib/currentUser'
 import { getPlanshipOnServer } from '@/lib/planship'
-import { Planship } from '@planship/fetch'
+import type { Planship } from '@planship/fetch'
 
 export default async function Analytics() {
   const planshipClient: Planship = getPlanshipOnServer()

--- a/src/app/api/click/route.ts
+++ b/src/app/api/click/route.ts
@@ -1,4 +1,4 @@
-import { Planship, TokenResponse } from '@planship/fetch'
+import type { Planship } from '@planship/fetch'
 import { getPlanshipOnServer } from '@/lib/planship'
 
 // Server API route that records and reports a button click

--- a/src/app/api/planshipToken/route.ts
+++ b/src/app/api/planshipToken/route.ts
@@ -1,4 +1,4 @@
-import { Planship, TokenResponse } from '@planship/fetch'
+import type { Planship, TokenResponse } from '@planship/fetch'
 import { getPlanshipOnServer } from '@/lib/planship'
 
 // Server API route that returns a Planship token fetched via a Planship API

--- a/src/app/components/CurrentUserProvider.tsx
+++ b/src/app/components/CurrentUserProvider.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { createContext, useContext, useState } from 'react'
+import { createContext, useContext } from 'react'
 import { getCurrentUser } from '@/lib/currentUser'
 
 interface ICurrentUserContext {

--- a/src/app/components/PlanSubscriptionView.tsx
+++ b/src/app/components/PlanSubscriptionView.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { RadioGroup } from '@headlessui/react'
-import { PlanDetails } from '@planship/fetch'
+import type { PlanDetails } from '@planship/fetch'
 import { useState, Fragment } from 'react'
 import { usePlanshipSubscription } from './PlanshipSubscriptionProvider'
 

--- a/src/app/components/PlanshipProvider.tsx
+++ b/src/app/components/PlanshipProvider.tsx
@@ -8,11 +8,11 @@ import { useCurrentUser } from './CurrentUserProvider'
 export default function PlanshipProvider({
   children,
   initialEntitlements,
-  initialSubscrptions
+  initialSubscriptions
 }: {
   children: React.ReactNode
   initialEntitlements: Entitlements
-  initialSubscrptions: CustomerSubscriptionWithPlan[]
+  initialSubscriptions: CustomerSubscriptionWithPlan[]
 }) {
   const currentUser = useCurrentUser()
   const PlanshipCustomerProvider = withPlanshipCustomerProvider(
@@ -22,7 +22,7 @@ export default function PlanshipProvider({
       getAccessToken
     },
     initialEntitlements,
-    initialSubscrptions
+    initialSubscriptions
   )
 
   return <PlanshipCustomerProvider>{children}</PlanshipCustomerProvider>

--- a/src/app/components/PlanshipProvider.tsx
+++ b/src/app/components/PlanshipProvider.tsx
@@ -2,7 +2,7 @@
 
 import { withPlanshipCustomerProvider } from '@planship/react'
 import { getAccessToken } from '@/lib/planship'
-import { CustomerSubscriptionWithPlan, Entitlements } from '@planship/fetch'
+import type { CustomerSubscriptionWithPlan, Entitlements } from '@planship/fetch'
 import { useCurrentUser } from './CurrentUserProvider'
 
 export default function PlanshipProvider({

--- a/src/app/components/PlanshipSubscriptionProvider.tsx
+++ b/src/app/components/PlanshipSubscriptionProvider.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, useState } from 'react'
 import { usePlanshipCustomer } from '@planship/react'
-import { CustomerSubscriptionWithPlan } from '@planship/fetch'
+import type { CustomerSubscriptionWithPlan } from '@planship/fetch'
 
 type changePlanFn = (newPlanSlug: string) => Promise<void>
 interface IPlanshipSubscriptionContext {

--- a/src/app/components/ProjectButton.tsx
+++ b/src/app/components/ProjectButton.tsx
@@ -2,10 +2,15 @@ import { useState } from 'react'
 import { usePlanshipCustomer } from '@planship/react'
 import { useCurrentUser } from './CurrentUserProvider'
 
+interface IProject {
+  name: string
+  type: string
+}
+
 function RenderProjectButton(projectType: string, projectName: string) {
-  const { entitlements, setEntitlements } = usePlanshipCustomer()
+  const { entitlements } = usePlanshipCustomer()
   const currentUser = useCurrentUser()
-  let [batchClicks, setBatchClicks] = useState(() => 5)
+  const [batchClicks, setBatchClicks] = useState(() => 5)
 
   const generateClicks = (count: number) => {
     fetch('/api/click', {
@@ -75,6 +80,6 @@ function RenderProjectButton(projectType: string, projectName: string) {
   }
 }
 
-export default function ProjectButton({ project, className }: { project: Object; className: string }) {
+export default function ProjectButton({ project, className }: { project: IProject; className: string }) {
   return <div className={className}>{RenderProjectButton(project.type, project.name)}</div>
 }

--- a/src/app/components/ProjectsView.tsx
+++ b/src/app/components/ProjectsView.tsx
@@ -8,10 +8,10 @@ import { usePlanshipCustomer } from '@planship/react'
 
 export default function ProjectsView() {
   const { entitlements } = usePlanshipCustomer()
-  let [newProjectName, setNewProjectName] = useState('New project')
-  let [newProjectType, setNewProjectType] = useState('Single')
-  let [isOpen, setIsOpen] = useState(false)
-  let [projectsLoaded, setProjectsLoaded] = useState(true)
+  const [newProjectName, setNewProjectName] = useState('New project')
+  const [newProjectType, setNewProjectType] = useState('Single')
+  const [isOpen, setIsOpen] = useState(false)
+  const [projectsLoaded, setProjectsLoaded] = useState(true)
 
   const [projects, setProjects] = useState([
     { name: 'First project', type: 'Single' },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next'
 import PlanshipProvider from './components/PlanshipProvider'
-import { getPlanshipOnServer } from './lib/planship'
-import { Planship } from '@planship/fetch'
+import { fetchSubscriptions, fetchEntitlements } from './lib/planship'
 import './globals.css'
 import { CurrentUserProvider } from './components/CurrentUserProvider'
 import NavBar from './components/NavBar'
@@ -15,14 +14,13 @@ export const metadata: Metadata = {
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const currentUser = getCurrentUser()
-  const apiClient: Planship = getPlanshipOnServer()
-  const entitlements = await apiClient.getEntitlements(currentUser.email)
-  const subscriptions = await apiClient.listSubscriptions(currentUser.email)
+  const subscriptions = await fetchSubscriptions(currentUser.email)
+  const entitlements = await fetchEntitlements(currentUser.email)
   return (
     <html lang="en">
       <body className="flex flex-col overflow-hidden h-[calc(100dvh)]">
         <CurrentUserProvider>
-          <PlanshipProvider initialEntitlements={entitlements} initialSubscrptions={subscriptions}>
+          <PlanshipProvider initialEntitlements={entitlements} initialSubscriptions={subscriptions}>
             <PlanshipSubscriptionProvider>
               <NavBar />
               <div className="flex-grow overflow-y-scroll">{children}</div>

--- a/src/app/lib/planship.ts
+++ b/src/app/lib/planship.ts
@@ -1,4 +1,6 @@
-import { Planship, CustomerSubscriptionWithPlan, ResponseError, Entitlements } from '@planship/fetch'
+import type { CustomerSubscriptionWithPlan, Entitlements } from '@planship/fetch'
+
+import { Planship } from '@planship/fetch'
 
 // Wrap nextjs fetch so there is no caching
 function planshipFetch(url, options) {
@@ -33,8 +35,8 @@ export async function fetchSubscriptions(userId: string): Promise<CustomerSubscr
   let customer
   try {
     customer = await planshipClient.getCustomer(userId)
-  } catch (error: ResponseError) {
-    if (error.response?.status === 404) {
+  } catch (error) {
+    if (error?.response?.status === 404) {
       // Create a Planship customer for the default user if one doesn't exist. This would typically be called during
       // a new customer sign-up, but this example app doesn't implement the sign-up/sign-in flow.
       customer = await planshipClient.createCustomer({ alternativeId: userId })
@@ -47,7 +49,9 @@ export async function fetchSubscriptions(userId: string): Promise<CustomerSubscr
     if (subscriptions.length > 0) {
       return subscriptions
     } else {
-      // Create an initial Planship subscriptio to the Personal plan for the default user if one doesn't exist.
+      // Create an initial Planship subscription to the Personal plan for the default user if one doesn't exist.
+      // This would typically be called when a customer chooses their initial plan upon sign-up, but this example app
+      // doesn't implement the sign-up/sign-in flow.
       return [await planshipClient.createSubscription(customer.id, 'personal')]
     }
   }

--- a/src/app/lib/planship.ts
+++ b/src/app/lib/planship.ts
@@ -1,4 +1,4 @@
-import { Planship } from '@planship/fetch'
+import { Planship, CustomerSubscriptionWithPlan, ResponseError } from '@planship/fetch'
 
 // Wrap nextjs fetch so there is no caching
 function planshipFetch(url, options) {
@@ -27,4 +27,30 @@ export async function getAccessToken() {
 
 export function getPlanshipOnServer() {
   return planshipClient
+}
+
+export async function fetchSubscriptions(userId: string) {
+  let customer
+  try {
+    customer = await planshipClient.getCustomer(userId)
+  } catch (error) {
+    if (error?.response?.status === 404) {
+      customer = await planshipClient.createCustomer({ alternativeId: userId })
+    } else {
+      throw error
+    }
+  }
+  if (customer) {
+    const subscriptions = await planshipClient.listSubscriptions(customer.id)
+    if (subscriptions.length > 0) {
+      return subscriptions
+    } else {
+      return [await planshipClient.createSubscription(customer.id, 'personal')]
+    }
+  }
+  return []
+}
+
+export async function fetchEntitlements(userId: string) {
+  return await planshipClient.getEntitlements(userId)
 }

--- a/src/app/subscription/page.tsx
+++ b/src/app/subscription/page.tsx
@@ -1,6 +1,6 @@
 import PlanSubscriptionView from '@/components/PlanSubscriptionView'
 import { getPlanshipOnServer } from '@/lib/planship'
-import { Planship, Plan, PlanDetails } from '@planship/fetch'
+import type { Planship, Plan, PlanDetails } from '@planship/fetch'
 
 export default async function Plans() {
   const planshipClient: Planship = getPlanshipOnServer()

--- a/src/app/subscription/page.tsx
+++ b/src/app/subscription/page.tsx
@@ -5,13 +5,7 @@ import { Planship, Plan, PlanDetails } from '@planship/fetch'
 export default async function Plans() {
   const planshipClient: Planship = getPlanshipOnServer()
   const planList: Plan[] = await planshipClient.listPlans()
-  const plans: PlanDetails[] = await Promise.all(
-    planList.map(async ({ slug }) => {
-      const plan: PlanDetails = await planshipClient.getPlan(slug)
-      plan.entitlements.sort((planA, planB) => planA.order - planB.order)
-      return plan
-    })
-  )
+  const plans: PlanDetails[] = await Promise.all(planList.map(async ({ slug }) => await planshipClient.getPlan(slug)))
 
   return (
     <main>


### PR DESCRIPTION
This PR, when merged, will fix a problem where no default customer (and/or subscription) exists for the 'clicker-demo' product. The new `fetchSubscriptions` functions will create a Planship customer for the default id ('vader@empire.gov') if one doesn't exist, as well as initial subscription to the 'Personal' plan for this customer.

Other changes include:
1.  Remove plan entitlements sorting (done on the server side now).
2. Extend eslint config with recommended typescript rules, including [import type enforcement](https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how)
3. Fix linting errors flagged by new eslint rules
