### PR TITLE
Remove clicks per minute

### DIFF
--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -47,8 +47,7 @@ export default function NavBar() {
             </div>
             <div className="grow" />
             <div className="flex flex-col md:flex-row mt-3 md:mt-0 md:items-center">
-              <div className="nav-caption">Subscription clicks left: {entitlements.subscriptionButtonClicks}</div>
-              <div className="nav-caption">Clicks left this minute: {entitlements.buttonClicksPerMinute}</div>
+              <div className="nav-caption">Button clicks left: {entitlements.subscriptionButtonClicks}</div>
             </div>
           </div>
           <div className="shrink-0">

--- a/src/app/components/PlanshipCustomerProvider.tsx
+++ b/src/app/components/PlanshipCustomerProvider.tsx
@@ -11,16 +11,8 @@ export class ClickerEntitlements extends EntitlementsBase {
     return this.entitlementsDict?.['subscription-button-clicks'].valueOf()
   }
 
-  get buttonClicksPerMinute(): number {
-    return this.entitlementsDict?.['button-clicks-per-minute']
-  }
-
   get maxProjects(): number {
     return this.entitlementsDict?.['max-projects']
-  }
-
-  get premiumButton(): boolean {
-    return this.entitlementsDict?.['premium-button']
   }
 
   get analyticsPanel(): boolean {

--- a/src/app/components/ProjectButton.tsx
+++ b/src/app/components/ProjectButton.tsx
@@ -29,7 +29,7 @@ function RenderProjectButton(projectType: string, projectName: string) {
   }
 
   const canGenerateButtonClick = () =>
-    entitlements.subscriptionButtonClicks > 0 && entitlements.buttonClicksPerMinute > 0
+    entitlements.subscriptionButtonClicks > 0
 
   switch (projectType) {
     case 'Single':


### PR DESCRIPTION
This PR, when merged, will remove clicks per minute metered lever from the example project. The reason for this change is that custom time period aggregation formulas are not supported on the [Free plan](https://planship.io/pricing).