### PR TITLE
Fix broken docs links in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ All of the pricing logic including subscription management, feature and usage en
 
 ## Getting started
 
-To get started, sign up for Planship at https://app.planship.io/auth/sign-up and navigate to the default organization automatically created for you. You will then see a `Clicker Demo` product and default Planship API credentials.
+To get started, [sign up for Planship](https://app.planship.io/auth/sign-up) and navigate to the default organization automatically created for you. You will then see a `Clicker Demo` product and default Planship API credentials.
 
 ![Screenshot of the Planship Console credentials view](assets/planship-creds.png)
 
@@ -42,4 +42,4 @@ pnpm dev
 
 ## Next steps
 
-To get started with Planship for your own product, check out the [Planship integration guide](https://docs.planship.io/integration). You may also want to read more about core concepts like [feature levers](https://docs.planship.io/planship/feature-levers/), [metered usage](https://docs.planship.io/planship/metered-usage/), and [plans](https://docs.planship.io/planship/plans/).
+To get started with Planship for your own product, check out the [Planship integration guide](https://docs.planship.io/integration). You may also want to read more about core concepts like [feature levers](https://docs.planship.io/concepts/feature-levers/), [metered usage](https://docs.planship.io/concepts/metered-levers/), and [plans](https://docs.planship.io/concepts/plans/).


### PR DESCRIPTION
This PR fixes broken documentation links in the README and closes #9.